### PR TITLE
This pull request fixes issues with submission format unmatching in 0.3.0 and 0.4.2

### DIFF
--- a/scripts/log_to_submission.py
+++ b/scripts/log_to_submission.py
@@ -12,6 +12,7 @@ from tqdm.auto import tqdm
 
 from lm_eval.loggers.evaluation_tracker import GeneralConfigTracker
 
+
 BENCHMARK_STORAGE: Optional[str] = "ai-forever/MERA"
 _TASKS = {}
 GENERATIVE_SUFFIX = "_gen"

--- a/scripts/log_to_submission.py
+++ b/scripts/log_to_submission.py
@@ -11,8 +11,8 @@ import numpy as np
 from tqdm.auto import tqdm
 
 from lm_eval.loggers.evaluation_tracker import GeneralConfigTracker
-
-
+#MERA_FOLDER=/workspace/MERA/fix-mera/mera_run_030/test_mera_run
+#MERA_MODEL_STRING="pretrained=/app/superllama,dtype=auto,max_length=16384"
 BENCHMARK_STORAGE: Optional[str] = "ai-forever/MERA"
 _TASKS = {}
 GENERATIVE_SUFFIX = "_gen"
@@ -370,7 +370,7 @@ class ruTiE(TextTask):
                 # check that question_id was passed to LM
                 if question_id_outputs is not None:
                     new_question = {
-                        "outputs": question_id_outputs,
+                        "outputs": question_id_outputs['outputs'],
                         "meta": {
                             "dialog_id": dialog_id,
                             "question_id": question_id,
@@ -402,6 +402,15 @@ class ruTiE(TextTask):
 
 @register_task
 class ruHumanEval(TextTask):
+
+    def outputs_to_submission(self, outputs):
+        res = []
+        for doc in outputs:
+            doc_id = int(self.doc_to_id(doc["doc"]))
+            resp = doc["filtered_resps"][0]
+            res.extend([self.doc_outputs_to_submission(doc_id, resp)])
+        return {"data": {"test": res}}
+    
     def doc_outputs_to_submission(self, doc_id, outputs):
         res = {
             "outputs": outputs,

--- a/scripts/log_to_submission.py
+++ b/scripts/log_to_submission.py
@@ -11,8 +11,7 @@ import numpy as np
 from tqdm.auto import tqdm
 
 from lm_eval.loggers.evaluation_tracker import GeneralConfigTracker
-#MERA_FOLDER=/workspace/MERA/fix-mera/mera_run_030/test_mera_run
-#MERA_MODEL_STRING="pretrained=/app/superllama,dtype=auto,max_length=16384"
+
 BENCHMARK_STORAGE: Optional[str] = "ai-forever/MERA"
 _TASKS = {}
 GENERATIVE_SUFFIX = "_gen"


### PR DESCRIPTION
RuTie in 0.3.0:
```
{
    "data": {
        "test": [
            [
                {
                    "outputs": "1",
                    "meta": {
                        "dialog_id": 0,
                        "question_id": 0
                    }
                },

```
RuTie in 0.4.2
```
{
    "data": {
        "test": [
            [
                {
                    "outputs": {
                        "outputs": "1",
                        "meta": {
                            "id": 0
                        }
                    },
                    "meta": {
                        "dialog_id": 0,
                        "question_id": 0
                    }
                },
```

RuHumanEval in 0.3.0
```
{
    "data": {
        "test": [
            {
                "outputs": [
                    [
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null
                    ],
                    [
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null
                    ],
```
RuHumanEval in 0.4.2(Has double squared brackets in outputs)
```
{
    "data": {
        "test": [
            {
                "outputs": [
                    [
                        [
                            "None",
                            "None",
                            "None",
                            "None",
                            "None",
                            "None",
                            "None",
                            "None",
                            "None",
                            "None"
                        ],
                        [
                            "None",
                            "None",
                            "None",
                            "None",
                            "None",
                            "None",
                            "None",
                            "None",
                            "None",
                            "None"
                        ],
                        [
```